### PR TITLE
Update skiplock dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'delayed_job_active_record'
 gem 'good_job'
 gem 'queue_classic', github: 'QueueClassic/queue_classic'
 gem 'que'
-gem 'skiplock', github: 'vtt/skiplock'
+gem 'skiplock', github: 'vtt/skiplock', ref: "ea1afabd707e687236dbd173917c103d347e96df"
 
 # Use Redis to track job rates and synchronize workers.
 gem 'redis', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/vtt/skiplock.git
-  revision: 6648b15e8834e073b3f292adc83bb996a711394b
+  revision: ea1afabd707e687236dbd173917c103d347e96df
+  ref: ea1afabd707e687236dbd173917c103d347e96df
   specs:
-    skiplock (1.0.1)
+    skiplock (1.0.2)
       activejob (>= 5.2.0)
       activerecord (>= 5.2.0)
       concurrent-ruby (>= 1.0.2)
@@ -47,7 +48,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     crass (1.0.6)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
@@ -66,14 +67,14 @@ GEM
       thor (>= 0.14.1)
       zeitwerk (>= 2.0)
     hiredis (0.6.3)
-    i18n (1.8.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.4.0)
-    minitest (5.14.2)
+    minitest (5.14.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parse-cron (0.1.4)
@@ -100,9 +101,9 @@ GEM
     redis (3.0.7)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -120,4 +121,4 @@ DEPENDENCIES
   skiplock!
 
 BUNDLED WITH
-   2.1.4
+   2.2.13


### PR DESCRIPTION
Update to #1.

```
  Fetching gem metadata from https://rubygems.org/..............
  Fetching https://github.com/vtt/skiplock.git
  fatal: Could not parse object '6648b15e8834e073b3f292adc83bb996a711394b'.
  Git error: command `git reset --hard 6648b15e8834e073b3f292adc83bb996a711394b`
  in directory
  /home/runner/work/queue-shootout/queue-shootout/vendor/bundle/ruby/2.7.0/bundler/gems/skiplock-6648b15e8834
  has failed.
  Revision 6648b15e8834e073b3f292adc83bb996a711394b does not exist in the
  repository https://github.com/vtt/skiplock.git. Maybe you misspelled it?
  If this error persists you could try removing the cache directory
  '/home/runner/work/queue-shootout/queue-shootout/vendor/bundle/ruby/2.7.0/cache/bundler/git/skiplock-f96e5895488337e26119ef96da76ee9681357548'
```